### PR TITLE
Python: Completion queue creation API changes

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pyx.pxi
@@ -40,7 +40,7 @@ cdef class CompletionQueue:
   def __cinit__(self):
     grpc_init()
     with nogil:
-      self.c_completion_queue = grpc_completion_queue_create(NULL)
+      self.c_completion_queue = grpc_completion_queue_create(GRPC_CQ_NEXT, GRPC_CQ_DEFAULT_POLLING, NULL)
     self.is_shutting_down = False
     self.is_shutdown = False
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -309,7 +309,20 @@ cdef extern from "grpc/grpc.h":
   void grpc_init() nogil
   void grpc_shutdown() nogil
 
-  grpc_completion_queue *grpc_completion_queue_create(void *reserved) nogil
+  ctypedef enum grpc_cq_completion_type:
+    GRPC_CQ_NEXT = 1
+    GRPC_CQ_PLUCK = 2
+
+  ctypedef enum grpc_cq_polling_type:
+    GRPC_CQ_DEFAULT_POLLING
+    GRPC_CQ_NON_LISTENING
+    GRPC_CQ_NON_POLLING
+
+  grpc_completion_queue *grpc_completion_queue_create(
+        grpc_cq_completion_type completion_type,
+        grpc_cq_polling_type polling_type,
+        void *reserved) nogil
+
   grpc_event grpc_completion_queue_next(grpc_completion_queue *cq,
                                         gpr_timespec deadline,
                                         void *reserved) nogil


### PR DESCRIPTION
Changes in python to use the new `grpc_completion_queue_create()` API
(This is built on top of my existing pull request https://github.com/grpc/grpc/pull/9972)
