### PR TITLE
PHP: Completion queue create API changes 

### DIFF
--- a/src/php/ext/grpc/completion_queue.c
+++ b/src/php/ext/grpc/completion_queue.c
@@ -38,13 +38,12 @@
 grpc_completion_queue *completion_queue;
 
 void grpc_php_init_completion_queue(TSRMLS_D) {
-  completion_queue = grpc_completion_queue_create(NULL);
+  completion_queue = grpc_completion_queue_create(GRPC_CQ_PLUCK,
+                                                  GRPC_CQ_DEFAULT_POLLING,
+                                                  NULL);
 }
 
 void grpc_php_shutdown_completion_queue(TSRMLS_D) {
   grpc_completion_queue_shutdown(completion_queue);
-  while (grpc_completion_queue_next(completion_queue,
-                                    gpr_inf_future(GPR_CLOCK_REALTIME),
-                                    NULL).type != GRPC_QUEUE_SHUTDOWN);
   grpc_completion_queue_destroy(completion_queue);
 }


### PR DESCRIPTION
- Since PHP only uses `grpc_completion_queue_pluck`, I changed the `grpc_completion_queue_create` to take `GRPC_CQ_PLUCK and GRPC_CQ_DEFAULT_POLLING` args

- Removed the redundant `grpc_completion_queue_next()` loop in `grpc_php_shutdown_completion_queue` function as it is no longer needed. This was most likely an artifact of a previous version of grpc-core where completion queues did not have a _"one tag in, one tag out"_ rule